### PR TITLE
Add diagnostics and improve Hydrojet control handling

### DIFF
--- a/custom_components/bestway/climate.py
+++ b/custom_components/bestway/climate.py
@@ -266,9 +266,11 @@ class AirjetV01HydrojetSpaThermostat(BestwayEntity, ClimateEntity):
             return
 
         if hvac_mode := kwargs.get(ATTR_HVAC_MODE):
-            should_heat = hvac_mode == HVACMode.HEAT
+            heat_mode = (
+                HydrojetHeat.ON if hvac_mode == HVACMode.HEAT else HydrojetHeat.OFF
+            )
             await self.coordinator.api.hydrojet_spa_set_heat(
-                self.device_id, should_heat
+                self.device_id, heat_mode
             )
 
         await self.coordinator.api.hydrojet_spa_set_target_temp(

--- a/custom_components/bestway/diagnostics.py
+++ b/custom_components/bestway/diagnostics.py
@@ -1,0 +1,59 @@
+"""Diagnostics support for the Bestway integration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .bestway.api import BestwayApi
+from .const import CONF_PASSWORD, CONF_USER_TOKEN, CONF_USERNAME, DOMAIN
+
+TO_REDACT = {CONF_PASSWORD, CONF_USER_TOKEN, CONF_USERNAME}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> Mapping[str, object]:
+    """Return diagnostics for a config entry."""
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    sanitized_devices = BestwayApi._sanitize_bindings_response(  # pylint: disable=protected-access
+        {
+            "devices": [
+                {
+                    "did": device.device_id,
+                    "product_name": device.product_name,
+                    "dev_alias": device.alias,
+                    "mcu_soft_version": device.mcu_soft_version,
+                    "mcu_hard_version": device.mcu_hard_version,
+                    "wifi_soft_version": device.wifi_soft_version,
+                    "wifi_hard_version": device.wifi_hard_version,
+                    "is_online": device.is_online,
+                }
+                for device in coordinator.api.devices.values()
+            ]
+        }
+    )["devices"]
+
+    status_snapshot: dict[str, object] = {}
+    devices_state = getattr(coordinator.data, "devices", {})
+    for device_id, status in devices_state.items():
+        status_snapshot["*" * len(device_id)] = {
+            "timestamp": status.timestamp,
+            "attrs": status.attrs,
+        }
+
+    return {
+        "config_entry": {
+            "entry_id": entry.entry_id,
+            "title": entry.title,
+            "data": async_redact_data(entry.data, TO_REDACT),
+        },
+        "devices": sanitized_devices,
+        "status": status_snapshot,
+    }
+

--- a/custom_components/bestway/number.py
+++ b/custom_components/bestway/number.py
@@ -68,3 +68,4 @@ class PoolFilterTimeNumber(BestwayEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         await self.coordinator.api.pool_filter_set_time(self.device_id, int(value))
+        await self.coordinator.async_refresh()

--- a/custom_components/bestway/select.py
+++ b/custom_components/bestway/select.py
@@ -130,3 +130,4 @@ class ThreeWaySpaBubblesSelect(BestwayEntity, SelectEntity):
         await self.entity_description.set_fn(
             self.coordinator.api, self.device_id, bubbles_level
         )
+        await self.coordinator.async_refresh()

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,77 @@
+"""Test helpers for the Bestway integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Iterable
+from unittest.mock import AsyncMock
+
+from custom_components.bestway.bestway.model import BestwayDevice
+
+
+def create_device(
+    device_id: str,
+    *,
+    product_name: str = "Hydrojet",
+    alias: str = "Bestway Spa",
+    protocol_version: int = 1,
+    mcu_soft_version: str = "1.0",
+    mcu_hard_version: str = "1.0",
+    wifi_soft_version: str = "1.0",
+    wifi_hard_version: str = "1.0",
+    is_online: bool = True,
+) -> BestwayDevice:
+    """Create a BestwayDevice instance for testing."""
+
+    return BestwayDevice(
+        protocol_version,
+        device_id,
+        product_name,
+        alias,
+        mcu_soft_version,
+        mcu_hard_version,
+        wifi_soft_version,
+        wifi_hard_version,
+        is_online,
+    )
+
+
+class MockBestwayCoordinator:
+    """Minimal coordinator implementation for entity tests."""
+
+    def __init__(
+        self,
+        hass,
+        *,
+        devices: Iterable[BestwayDevice] | None = None,
+        api_overrides: dict[str, object] | None = None,
+        data: object | None = None,
+        data_devices: dict[str, object] | None = None,
+    ) -> None:
+        self.hass = hass
+        self.last_update_success = True
+        self._listeners: list[object] = []
+        self.api = SimpleNamespace()
+        self.api.devices = {}
+        if devices:
+            self.api.devices.update({device.device_id: device for device in devices})
+        if api_overrides:
+            for name, value in api_overrides.items():
+                setattr(self.api, name, value)
+        self.async_refresh = AsyncMock()
+        if data is not None:
+            self.data = data
+        else:
+            self.data = SimpleNamespace(devices=data_devices or {})
+
+    def async_add_listener(self, update_callback):
+        """Pretend to register a coordinator listener."""
+
+        self._listeners.append(update_callback)
+
+        def _remove_listener():
+            if update_callback in self._listeners:
+                self._listeners.remove(update_callback)
+
+        return _remove_listener
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pycares
+
 import pytest
 
 pytest_plugins = "pytest_homeassistant_custom_component"
@@ -12,6 +14,16 @@ pytest_plugins = "pytest_homeassistant_custom_component"
 @pytest.fixture(autouse=True)
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable loading custom integrations."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def disable_pycares_shutdown_thread(monkeypatch):
+    """Prevent pycares from spawning a lingering shutdown thread during tests."""
+
+    monkeypatch.setattr(
+        pycares._ChannelShutdownManager, "start", lambda self: None
+    )
     yield
 
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,0 +1,52 @@
+"""Tests for the Bestway climate platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, call
+
+import pytest
+from homeassistant.components.climate.const import ATTR_HVAC_MODE, HVACMode
+from homeassistant.const import ATTR_TEMPERATURE
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bestway.climate import AirjetV01HydrojetSpaThermostat
+from custom_components.bestway.const import DOMAIN
+from custom_components.bestway.bestway.api import BestwayApiResults
+from custom_components.bestway.bestway.model import BestwayDeviceStatus, HydrojetHeat
+
+from .common import MockBestwayCoordinator, create_device
+
+
+@pytest.mark.parametrize(
+    ("requested_mode", "expected_heat"),
+    ((HVACMode.HEAT, HydrojetHeat.ON), (HVACMode.OFF, HydrojetHeat.OFF)),
+)
+async def test_hydrojet_set_temperature_translates_hvac_mode(
+    hass, requested_mode: HVACMode, expected_heat: HydrojetHeat
+) -> None:
+    """The Hydrojet thermostat should pass HydrojetHeat enums to the API."""
+
+    device = create_device("device-1", product_name="Hydrojet")
+    coordinator = MockBestwayCoordinator(
+        hass,
+        devices=[device],
+        api_overrides={
+            "hydrojet_spa_set_heat": AsyncMock(),
+            "hydrojet_spa_set_target_temp": AsyncMock(),
+        },
+        data=BestwayApiResults(devices={device.device_id: BestwayDeviceStatus(0, {})}),
+    )
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="entry-1")
+    thermostat = AirjetV01HydrojetSpaThermostat(coordinator, config_entry, device.device_id)
+
+    await thermostat.async_set_temperature(
+        **{ATTR_TEMPERATURE: 30, ATTR_HVAC_MODE: requested_mode}
+    )
+
+    assert coordinator.api.hydrojet_spa_set_heat.await_args_list == [
+        call(device.device_id, expected_heat)
+    ]
+    coordinator.api.hydrojet_spa_set_target_temp.assert_awaited_once_with(
+        device.device_id, 30
+    )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -29,11 +29,21 @@ MOCK_USER_INPUT = {
 # since we only want to test the config flow. We test the
 # actual functionality of the integration in other test modules.
 @pytest.fixture(autouse=True)
-def bypass_setup_fixture():
+def bypass_setup_fixture(hass):
     """Prevent setup."""
-    with patch(
-        "custom_components.bestway.async_setup_entry",
-        return_value=True,
+    async def _mock_async_setup_entry(hass, entry):
+        hass.data.setdefault(DOMAIN, {})[entry.entry_id] = object()
+        return True
+
+    with (
+        patch(
+            "custom_components.bestway.async_setup_entry",
+            side_effect=_mock_async_setup_entry,
+        ),
+        patch(
+            "custom_components.bestway.async_unload_entry",
+            return_value=True,
+        ),
     ):
         yield
 

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,60 @@
+"""Tests for Bestway diagnostics."""
+
+from __future__ import annotations
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bestway.const import (
+    CONF_API_ROOT,
+    CONF_PASSWORD,
+    CONF_USER_TOKEN,
+    CONF_USERNAME,
+    DOMAIN,
+)
+from custom_components.bestway.diagnostics import async_get_config_entry_diagnostics
+from custom_components.bestway.bestway.api import BestwayApiResults
+from custom_components.bestway.bestway.model import BestwayDeviceStatus
+
+from .common import MockBestwayCoordinator, create_device
+
+
+async def test_diagnostics_mask_sensitive_information(hass) -> None:
+    """Diagnostics should redact sensitive config data and mask identifiers."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_USERNAME: "user@example.com",
+            CONF_PASSWORD: "secret",
+            CONF_USER_TOKEN: "token",
+            CONF_API_ROOT: "https://api.example.com",
+        },
+        entry_id="entry-1",
+        title="Bestway",
+    )
+
+    device = create_device("device-1", product_name="Hydrojet", alias="Spa")
+    status = BestwayDeviceStatus(1234567890, {"temp": 37})
+    coordinator = MockBestwayCoordinator(
+        hass,
+        devices=[device],
+        data=BestwayApiResults(devices={device.device_id: status}),
+    )
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    redacted_data = diagnostics["config_entry"]["data"]
+    assert redacted_data[CONF_USERNAME] != "user@example.com"
+    assert redacted_data[CONF_PASSWORD] != "secret"
+    assert redacted_data[CONF_USER_TOKEN] != "token"
+
+    sanitized_device = diagnostics["devices"][0]
+    assert sanitized_device["did"] != device.device_id
+    assert sanitized_device["dev_alias"] == "Spa"
+
+    status_keys = list(diagnostics["status"].keys())
+    assert status_keys
+    assert device.device_id not in status_keys
+    assert diagnostics["status"][status_keys[0]]["attrs"] == status.attrs

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,41 @@
+"""Tests for the Bestway number platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bestway.const import DOMAIN
+from custom_components.bestway.bestway.api import BestwayApiResults
+from custom_components.bestway.bestway.model import BestwayDeviceStatus
+from custom_components.bestway.number import PoolFilterTimeNumber, _POOL_FILTER_TIME
+
+from .common import MockBestwayCoordinator, create_device
+
+
+async def test_pool_filter_time_requests_refresh(hass) -> None:
+    """Setting the filter time should request a refresh."""
+
+    device = create_device("device-1", product_name="泳池过滤器")
+    coordinator = MockBestwayCoordinator(
+        hass,
+        devices=[device],
+        api_overrides={"pool_filter_set_time": AsyncMock()},
+        data=BestwayApiResults(
+            devices={device.device_id: BestwayDeviceStatus(0, {"time": 0})}
+        ),
+    )
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="entry-1")
+    number = PoolFilterTimeNumber(
+        coordinator,
+        config_entry,
+        device.device_id,
+        _POOL_FILTER_TIME,
+    )
+
+    await number.async_set_native_value(4)
+
+    coordinator.api.pool_filter_set_time.assert_awaited_once_with(device.device_id, 4)
+    coordinator.async_refresh.assert_awaited_once()

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,46 @@
+"""Tests for the Bestway select platform."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.bestway.const import DOMAIN
+from custom_components.bestway.bestway.api import BestwayApiResults
+from custom_components.bestway.bestway.model import BestwayDeviceStatus, BubblesLevel
+from custom_components.bestway.select import (
+    ThreeWaySpaBubblesSelect,
+    _AIRJET_V01_BUBBLES_SELECT_DESCRIPTION,
+)
+
+from .common import MockBestwayCoordinator, create_device
+
+
+async def test_bubbles_select_requests_refresh(hass) -> None:
+    """Selecting a bubbles option should trigger a refresh."""
+
+    device = create_device("device-1", product_name="Airjet_V01")
+    coordinator = MockBestwayCoordinator(
+        hass,
+        devices=[device],
+        api_overrides={"airjet_v01_spa_set_bubbles": AsyncMock()},
+        data=BestwayApiResults(
+            devices={device.device_id: BestwayDeviceStatus(0, {"wave": 0})}
+        ),
+    )
+
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, entry_id="entry-1")
+    select = ThreeWaySpaBubblesSelect(
+        coordinator,
+        config_entry,
+        device.device_id,
+        _AIRJET_V01_BUBBLES_SELECT_DESCRIPTION,
+    )
+
+    await select.async_select_option("MEDIUM")
+
+    coordinator.api.airjet_v01_spa_set_bubbles.assert_awaited_once_with(
+        device.device_id, BubblesLevel.MEDIUM
+    )
+    coordinator.async_refresh.assert_awaited_once()


### PR DESCRIPTION
## Summary
- ensure Hydrojet spa thermostat always forwards HydrojetHeat enum values and cover the behaviour in tests
- refresh coordinator state after three-way bubbles selection and pool filter timer writes
- expose a diagnostics endpoint with sanitized device/status data and test helpers to support the new coverage

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb6808243c8322b3d32296eea60049